### PR TITLE
Also bind the full class name in the service provider, not only the facade

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
+++ b/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
@@ -71,7 +71,7 @@ class VatCalculatorServiceProvider extends ServiceProvider
     protected function registerVatCalculator()
     {
         $this->app->bind('vatcalculator', '\Mpociot\VatCalculator\VatCalculator');
-        
+
         $this->app->bind('\Mpociot\VatCalculator\VatCalculator', function ($app) {
             $config = $app->make('Illuminate\Contracts\Config\Repository');
 

--- a/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
+++ b/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
@@ -70,7 +70,9 @@ class VatCalculatorServiceProvider extends ServiceProvider
      */
     protected function registerVatCalculator()
     {
-        $this->app->bind('vatcalculator', function ($app) {
+        $this->app->bind('vatcalculator', '\Mpociot\VatCalculator\VatCalculator');
+        
+        $this->app->bind('\Mpociot\VatCalculator\VatCalculator', function ($app) {
             $config = $app->make('Illuminate\Contracts\Config\Repository');
 
             return new \Mpociot\VatCalculator\VatCalculator($config);


### PR DESCRIPTION
I noticed a small glitch when using the Controller class, which comes in play when using the frontend integration.

A VatCalculator instance is injected in the constructor of this class. But when the container resolves this class, it doesn't use the binding defined in the service provider (`registerVatCalculator()`), as this only binds the facade, not the main class. For the main class, the container will just use basic reflection, which is ok most of the times, but it means the $config parameter is not set.

This results in not having the config set in this controller, and ultimately the frontend integration ignoring your custom config (e.g. the business_country_code).

This PR makes sure the \Mpociot\VatCalculator\VatCalculator class is also bound.
Thank you for your feedback and/or merging!