### PR TITLE
Only extend the base validator without creating new custom instance

### DIFF
--- a/src/Mpociot/VatCalculator/Validators/VatCalculatorValidatorExtension.php
+++ b/src/Mpociot/VatCalculator/Validators/VatCalculatorValidatorExtension.php
@@ -13,9 +13,9 @@ class VatCalculatorValidatorExtension
      * Usage: vat_number.
      *
      * @param string $attribute
-     * @param mixed $value
-     * @param array $parameters
-     * @param $validator
+     * @param mixed  $value
+     * @param array  $parameters
+     * @param        $validator
      *
      * @return bool
      */

--- a/src/Mpociot/VatCalculator/Validators/VatCalculatorValidatorExtension.php
+++ b/src/Mpociot/VatCalculator/Validators/VatCalculatorValidatorExtension.php
@@ -8,7 +8,6 @@ use Mpociot\VatCalculator\Facades\VatCalculator;
 
 class VatCalculatorValidatorExtension
 {
-
     /**
      * Usage: vat_number.
      *

--- a/src/Mpociot/VatCalculator/Validators/VatCalculatorValidatorExtension.php
+++ b/src/Mpociot/VatCalculator/Validators/VatCalculatorValidatorExtension.php
@@ -6,33 +6,25 @@ use Illuminate\Validation\Validator;
 use Mpociot\VatCalculator\Exceptions\VATCheckUnavailableException;
 use Mpociot\VatCalculator\Facades\VatCalculator;
 
-class VatCalculatorValidatorExtension extends Validator
+class VatCalculatorValidatorExtension
 {
-    /**
-     * Creates a new instance of ValidatorExtension.
-     */
-    public function __construct($translator, $data, $rules, $messages, array $customAttributes = [])
-    {
-        // Set custom validation error messages
-        if (!isset($messages['vat_number'])) {
-            $messages['vat_number'] = $translator->get(
-                'vatnumber-validator::validation.vat_number'
-            );
-        }
-        parent::__construct($translator, $data, $rules, $messages, $customAttributes);
-    }
 
     /**
      * Usage: vat_number.
      *
      * @param string $attribute
-     * @param mixed  $value
-     * @param array  $parameters
+     * @param mixed $value
+     * @param array $parameters
+     * @param $validator
      *
      * @return bool
      */
-    public function validateVatNumber($attribute, $value, $parameters)
+    public function validateVatNumber($attribute, $value, $parameters, $validator)
     {
+        $validator->setCustomMessages([
+            'vat_number' => $validator->getTranslator()->get('vatnumber-validator::validation.vat_number'),
+        ]);
+
         try {
             return VatCalculator::isValidVATNumber($value);
         } catch (VATCheckUnavailableException $e) {

--- a/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
+++ b/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
@@ -11,8 +11,6 @@ namespace Mpociot\VatCalculator;
 
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
-use Mpociot\VatCalculator\Facades\VatCalculator;
-use Mpociot\VatCalculator\Validators\VatCalculatorValidatorExtension;
 
 class VatCalculatorServiceProvider extends ServiceProvider
 {

--- a/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
+++ b/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
@@ -111,18 +111,8 @@ class VatCalculatorServiceProvider extends ServiceProvider
             'vatnumber-validator'
         );
 
-        // Registering the validator extension with the validator factory
-        $this->app['validator']->resolver(
-            function ($translator, $data, $rules, $messages, $customAttributes = []) {
-                return new VatCalculatorValidatorExtension(
-                    $translator,
-                    $data,
-                    $rules,
-                    $messages,
-                    $customAttributes
-                );
-            }
-        );
+        $this->app['validator']->extend('vat_number',
+            'Mpociot\VatCalculator\Validators\VatCalculatorValidatorExtension@validateVatNumber');
     }
 
     /**


### PR DESCRIPTION
Before that if you try to extend the validation class in your app you can't because you are already using custom instance for the validator. 

As you don't override any existing validation properties you can just extend the validator as per [laravel documentation](https://laravel.com/docs/5.1/validation#custom-validation-rules)


