### PR TITLE
Add taxPercentage() for Laravel Cashier 6.0

### DIFF
--- a/src/Mpociot/VatCalculator/Traits/BillableWithinTheEU.php
+++ b/src/Mpociot/VatCalculator/Traits/BillableWithinTheEU.php
@@ -76,4 +76,14 @@ trait BillableWithinTheEU
     {
         return VatCalculator::getTaxRateForCountry($this->userCountryCode, $this->userIsCompany) * 100;
     }
+    
+    /**
+     * Get the tax percentage to apply to the subscription for Cashier > 6.0
+     *
+     * @return int
+     */
+    public function taxPercentage()
+    {
+        return $this->getTaxPercent();
+    }
 }

--- a/src/Mpociot/VatCalculator/Traits/BillableWithinTheEU.php
+++ b/src/Mpociot/VatCalculator/Traits/BillableWithinTheEU.php
@@ -76,9 +76,9 @@ trait BillableWithinTheEU
     {
         return VatCalculator::getTaxRateForCountry($this->userCountryCode, $this->userIsCompany) * 100;
     }
-    
+
     /**
-     * Get the tax percentage to apply to the subscription for Cashier > 6.0
+     * Get the tax percentage to apply to the subscription for Cashier > 6.0.
      *
      * @return int
      */


### PR DESCRIPTION
In Laravel Cashier 6.0, the function to get tax rate is now ``taxPercentage()`` instead of ``getTaxPercent()``