### PR TITLE
Allow usage of an hidden country field

### DIFF
--- a/src/public/js/vat_calculator.js
+++ b/src/public/js/vat_calculator.js
@@ -8,7 +8,7 @@
     function bindCalculatorEvents() {
         var form = document.querySelector(VATCalculator.selector);
         if (form !== null) {
-            var dropDown = form.querySelector('[' + DATA_PREFIX + '="country"]');
+            var dropDown = form.querySelector('select[' + DATA_PREFIX + '="country"]');
             if (dropDown !== null) {
                 dropDown.addEventListener('change', calculate);
                 // Try to preselect based on the user IP


### PR DESCRIPTION
Better detection of the dropDown (should be a `select` element with `data-vat="country"`)

If we already know the client country, we can use an hidden field and vat-calculator.js will work the same way.