### PR TITLE
Fix postal code exceptions causing VAT to be zero-rated.

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -543,10 +543,8 @@ class VatCalculator
         if (isset($this->config) && $this->config->has($taxKey)) {
             return $this->config->get($taxKey, 0);
         }
-
-        if (!isset($this->postalCodeExceptions[$countryCode]) || $postalCode === null) {
-            return isset($this->taxRules[strtoupper($countryCode)]['rate']) ? $this->taxRules[strtoupper($countryCode)]['rate'] : 0;
-        } else {
+        
+        if (isset($this->postalCodeExceptions[$countryCode]) && $postalCode !== null) {
             foreach ($this->postalCodeExceptions[$countryCode] as $postalCodeException) {
                 if (!preg_match($postalCodeException['postalCode'], $postalCode)) {
                     continue;
@@ -557,9 +555,9 @@ class VatCalculator
 
                 return $this->taxRules[$postalCodeException['code']]['rate'];
             }
-
-            return 0;
         }
+
+        return isset($this->taxRules[strtoupper($countryCode)]['rate']) ? $this->taxRules[strtoupper($countryCode)]['rate'] : 0;
     }
 
     /**

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -549,6 +549,28 @@ class VatCalculatorTest extends PHPUnit
         $this->assertEquals(5.28, $vatCalculator->getTaxValue());
     }
 
+    public function testPostalCodesWithoutExceptionsGetStandardRate()
+    {
+        $net = 24.00;
+        $vatCalculator = new VatCalculator();
+
+        // Invalid post code
+        $postalCode = 'IGHJ987ERT35';
+        $result = $vatCalculator->calculate($net, 'ES', $postalCode, false);
+        //Expect standard rate for Spain
+        $this->assertEquals(29.04, $result);
+        $this->assertEquals(0.21, $vatCalculator->getTaxRate());
+        $this->assertEquals(5.04, $vatCalculator->getTaxValue());
+
+        // Valid UK post code
+        $postalCode = 'S1A 2AA';
+        $result = $vatCalculator->calculate($net, 'GB', $postalCode, false);
+        //Expect standard rate for UK
+        $this->assertEquals(28.80, $result);
+        $this->assertEquals(0.20, $vatCalculator->getTaxRate());
+        $this->assertEquals(4.80, $vatCalculator->getTaxValue());
+    }
+
     public function testShouldCollectVAT()
     {
         $vatCalculator = new VatCalculator();


### PR DESCRIPTION
Fixes #30, by returning the default rate after checking for post code exceptions.