### PR TITLE
Romania VAT updated its from 20 to 19% on January 1st 2017

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -137,7 +137,7 @@ class VatCalculator
             ],
         ],
         'RO' => [ // Romania
-            'rate' => 0.20,
+            'rate' => 0.19,
         ],
         'SE' => [ // Sweden
             'rate' => 0.25,


### PR DESCRIPTION
Romania VAT updated its from 20 to 19% on January 1st 2017