### PR TITLE
Fix VAT Calculator JS returns zero tax for business country code

### DIFF
--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -15,9 +15,10 @@ class Controller extends BaseController
      */
     private $calculator;
 
-    public function __construct(VatCalculator $calculator)
+    public function __construct()
     {
-        $this->calculator = $calculator;
+        $config = resolve('Illuminate\Contracts\Config\Repository');
+        $this->calculator = new \Mpociot\VatCalculator\VatCalculator($config);
     }
 
     /**


### PR DESCRIPTION
Fixes #45 , by loading the (global) config in the constructor and create
a new instance that passes the config as argument.