### PR TITLE
Added functionality for high and low tax types

### DIFF
--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -839,4 +839,32 @@ class VatCalculatorTest extends PHPUnit
         $this->assertEquals(0, $vatCalculator->getTaxRate());
         $this->assertEquals(0, $vatCalculator->getTaxValue());
     }
+
+    public function testCalculateHighVatType()
+    {
+        $gross = 24.00;
+        $countryCode = 'NL';
+        $company = false;
+        $type = 'high';
+        $postalCode = null;
+
+        $vatCalculator = new VatCalculator();
+        $result = $vatCalculator->calculate($gross, $countryCode, $postalCode, $company, $type);
+
+        $this->assertEquals(29.04, $result);
+    }
+
+    public function testCalculateLowVatType()
+    {
+        $gross = 24.00;
+        $countryCode = 'NL';
+        $company = false;
+        $type = 'low';
+        $postalCode = null;
+
+        $vatCalculator = new VatCalculator();
+        $result = $vatCalculator->calculate($gross, $countryCode, $postalCode, $company, $type);
+
+        $this->assertEquals(25.44, $result);
+    }
 }


### PR DESCRIPTION
In the Netherlands we have more than one tax rate. 

High: 21% and Low: 6%.

https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/internationaal/btw_voor_buitenlandse_ondernemers/btw_berekenen/btw_tarieven/

I've added this functionality to this repository to help Dutch users.