### PR TITLE
Update README.php example for Cashier >6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ class User extends Model implements BillableContract
 {
     use Billable, BillableWithinTheEU {
         BillableWithinTheEU::getTaxPercent insteadof Billable;
+	
+	// for Cashier > 6.0 use the following instead (taxPercentage instead of getTaxPercent)
+	// BillableWithinTheEU::taxPercentage insteadof Billable;
     }
 
     protected $dates = ['trial_ends_at', 'subscription_ends_at'];


### PR DESCRIPTION
Cashier >6.0 uses the function`taxPercentage` instead of `getTaxPercent`. So I adapted the example in the README.php for the Cashier integration to make it easier to implement this.

With the previous example code you would get an
FatalErrorException (E_UNKNOWN)
Trait method taxPercentage has not been applied, because there are collisions with other trait methods on App\User