### PR TITLE
Add Laravel 5.5 package auto-discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ use Laravel\Cashier\Contracts\Billable as BillableContract;
 class User extends Model implements BillableContract
 {
     use Billable, BillableWithinTheEU {
-        BillableWithinTheEU::getTaxPercent insteadof Billable;
+        BillableWithinTheEU::taxPercentage insteadof Billable;
     }
 
     protected $dates = ['trial_ends_at', 'subscription_ends_at'];

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,15 @@
     "minimum-stability": "stable",
     "scripts": {
         "test": "phpunit"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mpociot\\VatCalculator\\VatCalculatorServiceProvider"
+            ],
+            "aliases": {
+                "VatCalculator": "Mpociot\\VatCalculator\\Facades\\VatCalculator"
+            }
+        }
     }
 }


### PR DESCRIPTION
This will make the package auto-discoverable.
Also fixes the wrong cashier method name in readme.