### PR TITLE
Correct regex for Madeira/Azores postcodes

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -274,12 +274,12 @@ class VatCalculator
         ],
         'PT' => [
             [
-                'postalCode' => '/^9[0-4]\d[2,]$/',
+                'postalCode' => '/^9[0-4]\d{2,}$/',
                 'code'       => 'PT',
                 'name'       => 'Madeira',
             ],
             [
-                'postalCode' => '/^9[5-9]\d[2,]$/',
+                'postalCode' => '/^9[5-9]\d{2,}$/',
                 'code'       => 'PT',
                 'name'       => 'Azores',
             ],


### PR DESCRIPTION
Changed `[2,]` (=match either digit 2 or comma) to `{2,}` (=match 2 or more times)