### PR TITLE
Remove non-breaking spaces from VAT ID

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -677,7 +677,7 @@ class VatCalculator
      */
     public function getVATDetails($vatNumber)
     {
-        $vatNumber = str_replace([' ', '-', '.', ','], '', trim($vatNumber));
+        $vatNumber = str_replace([' ', "\xC2\xA0", "\xA0", '-', '.', ','], '', trim($vatNumber));
         $countryCode = substr($vatNumber, 0, 2);
         $vatNumber = substr($vatNumber, 2);
         $this->initSoapClient();


### PR DESCRIPTION
Hi,

users sometimes copy and paste VAT ids from various resources using various formatting. The validation method already removes common separators.

This adds non-breaking space removal which is sometimes used as a number separator. It removes both Unicode and ISO-8859-x representation.

Though it might be handy for other users that's why I'm submitting this PR.

Thank you!