### PR TITLE
Bind using VatCalculator::class rather than string

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
+++ b/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php
@@ -69,9 +69,9 @@ class VatCalculatorServiceProvider extends ServiceProvider
      */
     protected function registerVatCalculator()
     {
-        $this->app->bind('vatcalculator', '\Mpociot\VatCalculator\VatCalculator');
+        $this->app->bind('vatcalculator', \Mpociot\VatCalculator\VatCalculator::class);
 
-        $this->app->bind('\Mpociot\VatCalculator\VatCalculator', function ($app) {
+        $this->app->bind(\Mpociot\VatCalculator\VatCalculator::class, function ($app) {
             $config = $app->make('Illuminate\Contracts\Config\Repository');
 
             return new \Mpociot\VatCalculator\VatCalculator($config);


### PR DESCRIPTION
There's every possibility I'm just doing something wrong, but when I resolve an instance of `VatCalulator` from the container it doesn't resolve [the instance we bind in the service provider](https://github.com/mpociot/vat-calculator/blob/master/src/Mpociot/VatCalculator/VatCalculatorServiceProvider.php#L74).

This appears to be because the name we are binding to contains a leading slash;
```
>>> '\Mpociot\VatCalculator\VatCalculator'
=> "\Mpociot\VatCalculator\VatCalculator"
>>> \Mpociot\VatCalculator\VatCalculator::class
=> "Mpociot\VatCalculator\VatCalculator"
```

If it's me and I should be doing something differently, please let me know! Thanks!

Edit: After more digging it seems that binding with leading slashes stopped being supported with Laravel 5.4;
```
Binding classes into the container with leading slashes is no longer supported. This feature required a significant amount of string formatting calls to be made within the container. Instead, simply register your bindings without a leading slash:
```
from https://laravel.com/docs/5.4/upgrade