### PR TITLE
Support date-based VAT rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The third parameter is the postal code of the customer.
 
 As a fourth parameter, you can pass in a boolean indicating whether the customer is a company or a private person. If the customer is a company, which you should check by <a href="#validate-eu-vat-numbers">validating the VAT number</a>, the net price gets returned.
 
+Fifth optional parameter defines which VAT rate to use if there are more defined for the particular country (`'high'`, `'low'`, `null` - the default when just one rate is defined).
+
+The sixth parameter, optional, specifies the date to use the VAT rate for. This is needed when a country changes its VAT rate and you want to calculate a price with the previous rate. Pass `DateTime` or `DateTimeImmutable` object. Current date used when not specified.
+
 
 ```php
 $grossPrice = VatCalculator::calculate( 24.00, 'DE', '12345', $isCompany = true );

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Mpociot\VatCalculator;
 
+use DateTimeImmutable;
 use Mockery as m;
 use PHPUnit_Framework_TestCase as PHPUnit;
 
@@ -69,7 +70,7 @@ class VatCalculatorTest extends PHPUnit
             ->andReturn(false);
 
         $vatCalculator = new VatCalculator($config);
-        $result = $vatCalculator->calculate($net, $countryCode);
+        $result = $vatCalculator->calculate($net, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(28.56, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -81,7 +82,7 @@ class VatCalculatorTest extends PHPUnit
         $countryCode = 'DE';
 
         $vatCalculator = new VatCalculator();
-        $result = $vatCalculator->calculate($net, $countryCode);
+        $result = $vatCalculator->calculate($net, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(28.56, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -151,7 +152,7 @@ class VatCalculatorTest extends PHPUnit
         $countryCode = 'DE';
 
         $vatCalculator = new VatCalculator();
-        $result = $vatCalculator->calculate($net, $countryCode);
+        $result = $vatCalculator->calculate($net, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(28.56, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -532,7 +533,7 @@ class VatCalculatorTest extends PHPUnit
             ->andReturn($countryCode);
 
         $vatCalculator = new VatCalculator($config);
-        $result = $vatCalculator->calculate($net, $countryCode, null, true);
+        $result = $vatCalculator->calculate($net, $countryCode, null, true, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(28.56, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -545,7 +546,7 @@ class VatCalculatorTest extends PHPUnit
 
         $vatCalculator = new VatCalculator();
         $vatCalculator->setBusinessCountryCode('DE');
-        $result = $vatCalculator->calculate($net, $countryCode, null, true);
+        $result = $vatCalculator->calculate($net, $countryCode, null, true, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(28.56, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -706,7 +707,7 @@ class VatCalculatorTest extends PHPUnit
             ->andReturn(false);
 
         $vatCalculator = new VatCalculator($config);
-        $result = $vatCalculator->calculateNet($gross, $countryCode);
+        $result = $vatCalculator->calculateNet($gross, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(24.00, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -718,7 +719,7 @@ class VatCalculatorTest extends PHPUnit
         $countryCode = 'DE';
 
         $vatCalculator = new VatCalculator();
-        $result = $vatCalculator->calculateNet($gross, $countryCode);
+        $result = $vatCalculator->calculateNet($gross, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(24.00, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -789,7 +790,7 @@ class VatCalculatorTest extends PHPUnit
 
         $vatCalculator = new VatCalculator();
 
-        $result = $vatCalculator->calculateNet($gross, $countryCode);
+        $result = $vatCalculator->calculateNet($gross, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
         $this->assertEquals(24.00, $result);
         $this->assertEquals(0.19, $vatCalculator->getTaxRate());
         $this->assertEquals(4.56, $vatCalculator->getTaxValue());
@@ -922,5 +923,27 @@ class VatCalculatorTest extends PHPUnit
         $result = $vatCalculator->calculate($gross, $countryCode, $postalCode, $company, $type);
 
         $this->assertEquals(26.16, $result);
+    }
+
+    public function testCalculateVatVariousDates()
+    {
+        $net = 24.00;
+        $countryCode = 'DE';
+
+        $vatCalculator = new VatCalculator();
+        $result = $vatCalculator->calculate($net, $countryCode, null, null, null, new DateTimeImmutable('2020-06-05 12:34:56'));
+        $this->assertEquals(28.56, $result);
+        $this->assertEquals(0.19, $vatCalculator->getTaxRate());
+        $this->assertEquals(4.56, $vatCalculator->getTaxValue());
+
+        $result = $vatCalculator->calculate($net, $countryCode, null, null, null, new DateTimeImmutable('2020-07-05 12:34:56'));
+        $this->assertEquals(27.84, $result);
+        $this->assertEquals(0.16, $vatCalculator->getTaxRate());
+        $this->assertEquals(3.84, $vatCalculator->getTaxValue());
+
+        $result = $vatCalculator->calculate($net, $countryCode, null, null, null, new DateTimeImmutable('2021-01-05 12:34:56'));
+        $this->assertEquals(28.56, $result);
+        $this->assertEquals(0.19, $vatCalculator->getTaxRate());
+        $this->assertEquals(4.56, $vatCalculator->getTaxValue());
     }
 }


### PR DESCRIPTION
Support date-based VAT rates in `calculate()`, `calculateNet()`, `getTaxRateForLocation()`

Pass a `DateTime`/`DateTimeImmutable` object and the lib will find a rate for that date, or for current date if not specified.

From now on, new or changed VAT rates should be added using the `since` key which has the same structure as the "parent" key (`rate`, `rates` keys). No existing values should be changed unless they're wrong.

Reverts #92, the default DE rate is back to 0.19 and the new rate (0.16) is valid only for the interval specified.

Fix #94

This is backported from my "standalone" and "modernized" fork https://github.com/spaze/vat-calculator/pull/5