### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, '8.0', 8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [6, 7, 8, 9, 10, 11, 12]
+        laravel: [6, 7, 8, 9, 10, 11, 12, 13]
         exclude:
           - php: 7.3
             laravel: 9
@@ -27,6 +27,8 @@ jobs:
             laravel: 11
           - php: 7.3
             laravel: 12
+          - php: 7.3
+            laravel: 13
           - php: 7.4
             laravel: 9
           - php: 7.4
@@ -35,12 +37,16 @@ jobs:
             laravel: 11
           - php: 7.4
             laravel: 12
+          - php: 7.4
+            laravel: 13
           - php: '8.0'
             laravel: 10
           - php: '8.0'
             laravel: 11
           - php: '8.0'
             laravel: 12
+          - php: '8.0'
+            laravel: 13
           - php: 8.1
             laravel: 6
           - php: 8.1
@@ -49,12 +55,16 @@ jobs:
             laravel: 11
           - php: 8.1
             laravel: 12
+          - php: 8.1
+            laravel: 13
           - php: 8.2
             laravel: 6
           - php: 8.2
             laravel: 7
           - php: 8.2
             laravel: 8
+          - php: 8.2
+            laravel: 13
           - php: 8.3
             laravel: 6
           - php: 8.3

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "ext-soap": "*"
     },
     "require-dev": {
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Add Laravel 13 to the supported versions in `composer.json` (`illuminate/contracts` and bump `orchestra/testbench` to allow `^11.0`)
- Extend the CI matrix in `.github/workflows/tests.yml` to run against Laravel 13 with the appropriate PHP exclusions

## Test plan
- [ ] CI matrix passes for Laravel 13 on supported PHP versions