### PR TITLE
GitHub Actions hardening

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,6 +2,9 @@ name: Coding Standards
 
 on: [push]
 
+permissions:
+  contents: write
+
 jobs:
   lint:
-    uses: laravel/.github/.github/workflows/coding-standards.yml@main
+    uses: laravel/.github/.github/workflows/coding-standards.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -98,10 +101,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, soap

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [released]
 
+permissions: {}
+
 jobs:
   update:
-    uses: laravel/.github/.github/workflows/update-changelog.yml@main
+    permissions:
+      contents: write
+    uses: laravel/.github/.github/workflows/update-changelog.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -636,7 +636,7 @@ class VatCalculator
     protected $ukValidationEndpoint = 'https://api.service.hmrc.gov.uk';
 
     /**
-     * @param \Illuminate\Contracts\Config\Repository|array
+     * @param Repository|array
      */
     public function __construct($config = [])
     {


### PR DESCRIPTION
We are doing 3 things across the organization:

1. Pinning GitHub Actions to full commit SHAs (instead of mutable tags/branches).
2. Tightening workflow `permissions:` to least-privilege (write scope only where a step needs it).
3. Adding a Dependabot config to keep the pinned actions updated.

This pull request is part of that work.